### PR TITLE
feat: Add support for custom service environment blueprints

### DIFF
--- a/API.md
+++ b/API.md
@@ -2095,13 +2095,13 @@ Check whether the given construct is a Resource.
 | <code><a href="#cdk-data-zone.Environment.property.awsAccountRegion">awsAccountRegion</a></code> | <code>string</code> | The AWS Region in which an environment exists. |
 | <code><a href="#cdk-data-zone.Environment.property.createdBy">createdBy</a></code> | <code>string</code> | The Amazon  user who created the environment. |
 | <code><a href="#cdk-data-zone.Environment.property.domainId">domainId</a></code> | <code>string</code> | The identifier of the Amazon  domain in which the environment exists. |
-| <code><a href="#cdk-data-zone.Environment.property.environmentBlueprintId">environmentBlueprintId</a></code> | <code>string</code> | The identifier of a blueprint with which an environment profile is created. |
+| <code><a href="#cdk-data-zone.Environment.property.environmentBlueprintId">environmentBlueprintId</a></code> | <code>string</code> | The identifier of a blueprint with which an environment profile, or a custom environment is created. |
 | <code><a href="#cdk-data-zone.Environment.property.environmentId">environmentId</a></code> | <code>string</code> | The identifier of the environment. |
-| <code><a href="#cdk-data-zone.Environment.property.environmentProfile">environmentProfile</a></code> | <code><a href="#cdk-data-zone.IEnvironmentProfile">IEnvironmentProfile</a></code> | The identifier of the environment profile with which the environment was created. |
 | <code><a href="#cdk-data-zone.Environment.property.name">name</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdk-data-zone.Environment.property.project">project</a></code> | <code><a href="#cdk-data-zone.IProject">IProject</a></code> | The identifier of the project in which the environment exists. |
 | <code><a href="#cdk-data-zone.Environment.property.provider">provider</a></code> | <code>string</code> | The provider of the environment. |
 | <code><a href="#cdk-data-zone.Environment.property.status">status</a></code> | <code>string</code> | The status of the environment. |
+| <code><a href="#cdk-data-zone.Environment.property.environmentProfile">environmentProfile</a></code> | <code><a href="#cdk-data-zone.IEnvironmentProfile">IEnvironmentProfile</a></code> | The identifier of the environment profile with which the environment was created. |
 
 ---
 
@@ -2228,7 +2228,7 @@ public readonly environmentBlueprintId: string;
 
 - *Type:* string
 
-The identifier of a blueprint with which an environment profile is created.
+The identifier of a blueprint with which an environment profile, or a custom environment is created.
 
 ---
 
@@ -2241,18 +2241,6 @@ public readonly environmentId: string;
 - *Type:* string
 
 The identifier of the environment.
-
----
-
-##### `environmentProfile`<sup>Required</sup> <a name="environmentProfile" id="cdk-data-zone.Environment.property.environmentProfile"></a>
-
-```typescript
-public readonly environmentProfile: IEnvironmentProfile;
-```
-
-- *Type:* <a href="#cdk-data-zone.IEnvironmentProfile">IEnvironmentProfile</a>
-
-The identifier of the environment profile with which the environment was created.
 
 ---
 
@@ -2299,6 +2287,18 @@ public readonly status: string;
 - *Type:* string
 
 The status of the environment.
+
+---
+
+##### `environmentProfile`<sup>Optional</sup> <a name="environmentProfile" id="cdk-data-zone.Environment.property.environmentProfile"></a>
+
+```typescript
+public readonly environmentProfile: IEnvironmentProfile;
+```
+
+- *Type:* <a href="#cdk-data-zone.IEnvironmentProfile">IEnvironmentProfile</a>
+
+The identifier of the environment profile with which the environment was created.
 
 ---
 
@@ -2474,11 +2474,11 @@ Check whether the given construct is a Resource.
 | <code><a href="#cdk-data-zone.EnvironmentBase.property.domainId">domainId</a></code> | <code>string</code> | The identifier of the Amazon  domain in which the environment exists. |
 | <code><a href="#cdk-data-zone.EnvironmentBase.property.environmentBlueprintId">environmentBlueprintId</a></code> | <code>string</code> | The identifier of a blueprint with which an environment profile is created. |
 | <code><a href="#cdk-data-zone.EnvironmentBase.property.environmentId">environmentId</a></code> | <code>string</code> | The identifier of the environment. |
-| <code><a href="#cdk-data-zone.EnvironmentBase.property.environmentProfile">environmentProfile</a></code> | <code><a href="#cdk-data-zone.IEnvironmentProfile">IEnvironmentProfile</a></code> | The identifier of the environment profile with which the environment was created. |
 | <code><a href="#cdk-data-zone.EnvironmentBase.property.name">name</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdk-data-zone.EnvironmentBase.property.project">project</a></code> | <code><a href="#cdk-data-zone.IProject">IProject</a></code> | The identifier of the project in which the environment exists. |
 | <code><a href="#cdk-data-zone.EnvironmentBase.property.provider">provider</a></code> | <code>string</code> | The provider of the environment. |
 | <code><a href="#cdk-data-zone.EnvironmentBase.property.status">status</a></code> | <code>string</code> | The status of the environment. |
+| <code><a href="#cdk-data-zone.EnvironmentBase.property.environmentProfile">environmentProfile</a></code> | <code><a href="#cdk-data-zone.IEnvironmentProfile">IEnvironmentProfile</a></code> | The identifier of the environment profile with which the environment was created. |
 
 ---
 
@@ -2621,18 +2621,6 @@ The identifier of the environment.
 
 ---
 
-##### `environmentProfile`<sup>Required</sup> <a name="environmentProfile" id="cdk-data-zone.EnvironmentBase.property.environmentProfile"></a>
-
-```typescript
-public readonly environmentProfile: IEnvironmentProfile;
-```
-
-- *Type:* <a href="#cdk-data-zone.IEnvironmentProfile">IEnvironmentProfile</a>
-
-The identifier of the environment profile with which the environment was created.
-
----
-
 ##### `name`<sup>Required</sup> <a name="name" id="cdk-data-zone.EnvironmentBase.property.name"></a>
 
 ```typescript
@@ -2676,6 +2664,18 @@ public readonly status: string;
 - *Type:* string
 
 The status of the environment.
+
+---
+
+##### `environmentProfile`<sup>Optional</sup> <a name="environmentProfile" id="cdk-data-zone.EnvironmentBase.property.environmentProfile"></a>
+
+```typescript
+public readonly environmentProfile: IEnvironmentProfile;
+```
+
+- *Type:* <a href="#cdk-data-zone.IEnvironmentProfile">IEnvironmentProfile</a>
+
+The identifier of the environment profile with which the environment was created.
 
 ---
 
@@ -6143,7 +6143,6 @@ const environmentOptions: EnvironmentOptions = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#cdk-data-zone.EnvironmentOptions.property.description">description</a></code> | <code>string</code> | The description of the environment. |
-| <code><a href="#cdk-data-zone.EnvironmentOptions.property.environmentRole">environmentRole</a></code> | <code>aws-cdk-lib.aws_iam.Role</code> | The ARN of the environment role. |
 | <code><a href="#cdk-data-zone.EnvironmentOptions.property.glossaryTerms">glossaryTerms</a></code> | <code>string[]</code> | The glossary terms that can be used in this Amazon  environment. |
 | <code><a href="#cdk-data-zone.EnvironmentOptions.property.name">name</a></code> | <code>string</code> | The name of the Amazon  environment. |
 | <code><a href="#cdk-data-zone.EnvironmentOptions.property.userParameters">userParameters</a></code> | <code>aws-cdk-lib.IResolvable \| aws-cdk-lib.IResolvable \| aws-cdk-lib.aws_datazone.CfnEnvironment.EnvironmentParameterProperty[]</code> | The user parameters of this Amazon  environment. |
@@ -6161,20 +6160,6 @@ public readonly description: string;
 The description of the environment.
 
 > [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-datazone-environment.html#cfn-datazone-environment-description](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-datazone-environment.html#cfn-datazone-environment-description)
-
----
-
-##### `environmentRole`<sup>Optional</sup> <a name="environmentRole" id="cdk-data-zone.EnvironmentOptions.property.environmentRole"></a>
-
-```typescript
-public readonly environmentRole: Role;
-```
-
-- *Type:* aws-cdk-lib.aws_iam.Role
-
-The ARN of the environment role.
-
-> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-datazone-environment.html#cfn-datazone-environment-environmentrolearn](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-datazone-environment.html#cfn-datazone-environment-environmentrolearn)
 
 ---
 
@@ -6354,27 +6339,16 @@ const environmentProps: EnvironmentProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#cdk-data-zone.EnvironmentProps.property.environmentProfile">environmentProfile</a></code> | <code><a href="#cdk-data-zone.IEnvironmentProfile">IEnvironmentProfile</a></code> | The identifier of the environment profile that is used to create this Amazon  environment. |
 | <code><a href="#cdk-data-zone.EnvironmentProps.property.name">name</a></code> | <code>string</code> | The name of the Amazon  environment. |
 | <code><a href="#cdk-data-zone.EnvironmentProps.property.project">project</a></code> | <code><a href="#cdk-data-zone.IProject">IProject</a></code> | The identifier of the Amazon  project in which this environment is created. |
 | <code><a href="#cdk-data-zone.EnvironmentProps.property.description">description</a></code> | <code>string</code> | The description of the environment. |
+| <code><a href="#cdk-data-zone.EnvironmentProps.property.environmentAccountId">environmentAccountId</a></code> | <code>string</code> | (Required for Custom Service Environments)  The AWS Region in which the custom service environment will be created in exists. |
+| <code><a href="#cdk-data-zone.EnvironmentProps.property.environmentAccountRegion">environmentAccountRegion</a></code> | <code>string</code> | (Required for Custom Service Environments) The identifier of an AWS account in which the custom service environment will be created in exists. |
+| <code><a href="#cdk-data-zone.EnvironmentProps.property.environmentBlueprintId">environmentBlueprintId</a></code> | <code>string</code> | The identifier of the custom aws service blueprint with which the environment is to be created. |
+| <code><a href="#cdk-data-zone.EnvironmentProps.property.environmentProfile">environmentProfile</a></code> | <code><a href="#cdk-data-zone.IEnvironmentProfile">IEnvironmentProfile</a></code> | The identifier of the environment profile that is used to create this Amazon DataZone Environment. |
 | <code><a href="#cdk-data-zone.EnvironmentProps.property.environmentRole">environmentRole</a></code> | <code>aws-cdk-lib.aws_iam.Role</code> | The ARN of the environment role. |
 | <code><a href="#cdk-data-zone.EnvironmentProps.property.glossaryTerms">glossaryTerms</a></code> | <code>string[]</code> | The glossary terms that can be used in this Amazon  environment. |
 | <code><a href="#cdk-data-zone.EnvironmentProps.property.userParameters">userParameters</a></code> | <code>aws-cdk-lib.IResolvable \| aws-cdk-lib.IResolvable \| aws-cdk-lib.aws_datazone.CfnEnvironment.EnvironmentParameterProperty[]</code> | The user parameters of this Amazon  environment. |
-
----
-
-##### `environmentProfile`<sup>Required</sup> <a name="environmentProfile" id="cdk-data-zone.EnvironmentProps.property.environmentProfile"></a>
-
-```typescript
-public readonly environmentProfile: IEnvironmentProfile;
-```
-
-- *Type:* <a href="#cdk-data-zone.IEnvironmentProfile">IEnvironmentProfile</a>
-
-The identifier of the environment profile that is used to create this Amazon  environment.
-
-> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-datazone-environment.html#cfn-datazone-environment-environmentprofileidentifier](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-datazone-environment.html#cfn-datazone-environment-environmentprofileidentifier)
 
 ---
 
@@ -6420,6 +6394,60 @@ The description of the environment.
 
 ---
 
+##### `environmentAccountId`<sup>Optional</sup> <a name="environmentAccountId" id="cdk-data-zone.EnvironmentProps.property.environmentAccountId"></a>
+
+```typescript
+public readonly environmentAccountId: string;
+```
+
+- *Type:* string
+
+(Required for Custom Service Environments)  The AWS Region in which the custom service environment will be created in exists.
+
+---
+
+##### `environmentAccountRegion`<sup>Optional</sup> <a name="environmentAccountRegion" id="cdk-data-zone.EnvironmentProps.property.environmentAccountRegion"></a>
+
+```typescript
+public readonly environmentAccountRegion: string;
+```
+
+- *Type:* string
+
+(Required for Custom Service Environments) The identifier of an AWS account in which the custom service environment will be created in exists.
+
+---
+
+##### `environmentBlueprintId`<sup>Optional</sup> <a name="environmentBlueprintId" id="cdk-data-zone.EnvironmentProps.property.environmentBlueprintId"></a>
+
+```typescript
+public readonly environmentBlueprintId: string;
+```
+
+- *Type:* string
+
+The identifier of the custom aws service blueprint with which the environment is to be created.
+
+> [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-datazone-environment.html](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-datazone-environment.html)
+
+---
+
+##### `environmentProfile`<sup>Optional</sup> <a name="environmentProfile" id="cdk-data-zone.EnvironmentProps.property.environmentProfile"></a>
+
+```typescript
+public readonly environmentProfile: IEnvironmentProfile;
+```
+
+- *Type:* <a href="#cdk-data-zone.IEnvironmentProfile">IEnvironmentProfile</a>
+
+The identifier of the environment profile that is used to create this Amazon DataZone Environment.
+
+(Not allowed for Custom Service Blueprints)
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-datazone-environment.html#cfn-datazone-environment-environmentprofileidentifier](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-datazone-environment.html#cfn-datazone-environment-environmentprofileidentifier)
+
+---
+
 ##### `environmentRole`<sup>Optional</sup> <a name="environmentRole" id="cdk-data-zone.EnvironmentProps.property.environmentRole"></a>
 
 ```typescript
@@ -6429,6 +6457,8 @@ public readonly environmentRole: Role;
 - *Type:* aws-cdk-lib.aws_iam.Role
 
 The ARN of the environment role.
+
+(Required For Custom Service Blueprints Only)
 
 > [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-datazone-environment.html#cfn-datazone-environment-environmentrolearn](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-datazone-environment.html#cfn-datazone-environment-environmentrolearn)
 
@@ -8270,10 +8300,10 @@ public addDataSource(name: string, options: DataSourceOptions): DataSource
 | <code><a href="#cdk-data-zone.IEnvironment.property.domainId">domainId</a></code> | <code>string</code> | The identifier of the Amazon  domain in which the environment exists. |
 | <code><a href="#cdk-data-zone.IEnvironment.property.environmentBlueprintId">environmentBlueprintId</a></code> | <code>string</code> | The identifier of a blueprint with which an environment profile is created. |
 | <code><a href="#cdk-data-zone.IEnvironment.property.environmentId">environmentId</a></code> | <code>string</code> | The identifier of the environment. |
-| <code><a href="#cdk-data-zone.IEnvironment.property.environmentProfile">environmentProfile</a></code> | <code><a href="#cdk-data-zone.IEnvironmentProfile">IEnvironmentProfile</a></code> | The identifier of the environment profile with which the environment was created. |
 | <code><a href="#cdk-data-zone.IEnvironment.property.project">project</a></code> | <code><a href="#cdk-data-zone.IProject">IProject</a></code> | The identifier of the project in which the environment exists. |
 | <code><a href="#cdk-data-zone.IEnvironment.property.provider">provider</a></code> | <code>string</code> | The provider of the environment. |
 | <code><a href="#cdk-data-zone.IEnvironment.property.status">status</a></code> | <code>string</code> | The status of the environment. |
+| <code><a href="#cdk-data-zone.IEnvironment.property.environmentProfile">environmentProfile</a></code> | <code><a href="#cdk-data-zone.IEnvironmentProfile">IEnvironmentProfile</a></code> | The identifier of the environment profile with which the environment was created. |
 
 ---
 
@@ -8416,18 +8446,6 @@ The identifier of the environment.
 
 ---
 
-##### `environmentProfile`<sup>Required</sup> <a name="environmentProfile" id="cdk-data-zone.IEnvironment.property.environmentProfile"></a>
-
-```typescript
-public readonly environmentProfile: IEnvironmentProfile;
-```
-
-- *Type:* <a href="#cdk-data-zone.IEnvironmentProfile">IEnvironmentProfile</a>
-
-The identifier of the environment profile with which the environment was created.
-
----
-
 ##### `project`<sup>Required</sup> <a name="project" id="cdk-data-zone.IEnvironment.property.project"></a>
 
 ```typescript
@@ -8461,6 +8479,18 @@ public readonly status: string;
 - *Type:* string
 
 The status of the environment.
+
+---
+
+##### `environmentProfile`<sup>Optional</sup> <a name="environmentProfile" id="cdk-data-zone.IEnvironment.property.environmentProfile"></a>
+
+```typescript
+public readonly environmentProfile: IEnvironmentProfile;
+```
+
+- *Type:* <a href="#cdk-data-zone.IEnvironmentProfile">IEnvironmentProfile</a>
+
+The identifier of the environment profile with which the environment was created.
 
 ---
 

--- a/src/environment-profile.ts
+++ b/src/environment-profile.ts
@@ -3,7 +3,6 @@
 
 import * as cdk from 'aws-cdk-lib';
 import * as datazone from 'aws-cdk-lib/aws-datazone';
-import * as iam from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
 import { IBlueprint } from './blueprint';
 import { Environment } from './environment';
@@ -19,12 +18,6 @@ export interface EnvironmentOptions {
      * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-datazone-environment.html#cfn-datazone-environment-description
      */
   readonly description?: string;
-  /**
-     * The ARN of the environment role.
-     *
-     * @see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-datazone-environment.html#cfn-datazone-environment-environmentrolearn
-     */
-  readonly environmentRole?: iam.Role;
   /**
      * The glossary terms that can be used in this Amazon  environment.
      *

--- a/test/environment.test.ts
+++ b/test/environment.test.ts
@@ -1,0 +1,85 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as cdk from 'aws-cdk-lib';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import { Domain, Project, Environment } from '../lib';
+
+describe('Environment', () => {
+
+  let stack: cdk.Stack;
+  let domain: Domain;
+  let project: Project;
+  const app = new cdk.App();
+  stack = new cdk.Stack(app, 'TestStack');
+
+
+  beforeEach(() => {
+    domain = new Domain(stack, 'TestDomain', {
+      name: 'test-domain',
+    });
+    project = domain.createProject('TestProject', {
+      name: 'test-project',
+      description: 'Test Project',
+    });
+    domain.enableBlueprint('testcustom1234');
+
+  });
+  let envActionRole = new iam.Role(stack, 'EnvActionRole', {
+    roleName: 'EnvironmentActionBYORRole',
+    assumedBy: new iam.CompositePrincipal(
+      new iam.ServicePrincipal('datazone.amazonaws.com'),
+      new iam.ServicePrincipal('datazone.aws.internal'),
+      new iam.ServicePrincipal('niceland.aws.internal'),
+      new iam.AccountPrincipal(cdk.Stack.of(stack).account), // Equivalent to root principal for the current account
+    ),
+    inlinePolicies: {
+      EnvActionAccessPolicy: new iam.PolicyDocument({
+        statements: [
+          new iam.PolicyStatement({
+            effect: iam.Effect.ALLOW,
+            actions: ['s3:*', 'datazone:*'],
+            resources: ['*'],
+          }),
+        ],
+      }),
+    },
+  });
+
+  // Additional AssumeRole permission for root account
+  envActionRole.assumeRolePolicy?.addStatements(
+    new iam.PolicyStatement({
+      sid: '',
+      effect: iam.Effect.ALLOW,
+      principals: [new iam.AccountPrincipal(cdk.Stack.of(stack).account)], // Root account access
+      actions: ['sts:AssumeRole'],
+    }),
+  );
+
+  test('creates a custom service environment', () => {
+    new Environment(stack, 'testEnvironment', {
+      environmentBlueprintId: 'ca1cnpesm1jx47',
+      name: 'test-environment',
+      project: project,
+      environmentRole: envActionRole,
+      environmentAccountId: cdk.Stack.of(stack).account,
+      environmentAccountRegion: 'us-east-1',
+      description: 'Test Environment',
+
+    });
+    const template = Template.fromStack(stack);
+
+    template.hasResourceProperties('AWS::DataZone::Environment', {
+      Name: 'test-environment',
+      Description: 'Test Environment',
+      DomainIdentifier: {
+        'Fn::GetAtt': [Match.stringLikeRegexp('TestDomain.*'), 'DomainId'],
+      },
+      EnvironmentRoleArn: {
+        'Fn::GetAtt': [Match.stringLikeRegexp('EnvActionRole.*'), 'Arn'],
+      },
+    });
+  });
+
+});


### PR DESCRIPTION
### Changes 
- Update environment.ts to take in environmentBluerprintIdentifier. This allows for support of custom service environment in datazone as this is a required field
- Removed environmentRoleArn from environment-profile.ts since environment profile does not support this
- Added custom service environment test
- Updated documentation 

### Justification
https://docs.aws.amazon.com/datazone/latest/userguide/working-with-custom-blueprint.html
Custom Service Blueprints are unique in that they do not require environment profiles. They require the blueprint Id, and the environment account id, environment account region. They are a synchronous for of environment creation. Currently, there is a customer trying to use this package and cannot pass in the blueprint identifier, since custom service blueprints dont have an environment profile the environment creation in cloud formation fails. Below is a comparison between a working CFN template and one synthesized from this package before the above change

Synthesized with this library  (Json)

```
{

  "Resources": {
    "TestDataZoneEnvironment": {
      "Type": "AWS::DataZone::Environment",
      "Properties": {
        "Description": "Automated test environment for AWS DataZone",
        "DomainIdentifier": "dzd_cv8vsjuej8xt0n",
        "EnvironmentAccountIdentifier": "624699565525",
        "EnvironmentAccountRegion": "us-east-1",
        "EnvironmentRoleArn": "arn:aws:iam::624699565525:role/Admin",
        "Name": "TestEnvironment",
        "ProjectIdentifier": "bdffz2y3yajvvr"
      },
      "DeletionPolicy": "Retain"
    }
  }
}
```


Expected Template to Work with CFN (Yaml -My Personal Preference)

```
Environment:

    Type: "AWS::DataZone::Environment"
    DependsOn: EnableBlueprint
    Properties:
      ProjectIdentifier: !GetAtt EnvironmentActionProject.Id
      DomainIdentifier: !GetAtt Domain.Id
      Description: "Testing Env for Env Action Integration tests"
      Name: "BaseEnvironment"
      EnvironmentBlueprintId: !GetAtt EnableBlueprint.EnvironmentBlueprintId
      EnvironmentAccountIdentifier: !Ref "AWS::AccountId"
      EnvironmentAccountRegion: !Ref "AWS::Region"
      EnvironmentRoleArn: !GetAtt EnvActionRole.Arn
```

### Testing
- All automated tests are passing'
- Added additional test for environment creation with just custom blueprints 


### Author (Vincent Pietropaolo (vapp)) - Original developer of custom service blueprints for datazone (Both backend and CFN IAC code)